### PR TITLE
Added option `vendor/bin/lang status --columns=12`

### DIFF
--- a/src/Commands/Status.php
+++ b/src/Commands/Status.php
@@ -3,9 +3,11 @@
 namespace LaravelLang\StatusGenerator\Commands;
 
 use LaravelLang\StatusGenerator\Constants\Command as CommandName;
+use LaravelLang\StatusGenerator\Constants\Option;
 use LaravelLang\StatusGenerator\Processors\Status\CleanUp as CleanUpProcessor;
 use LaravelLang\StatusGenerator\Processors\Status\Localization as LocalizationProcessor;
 use LaravelLang\StatusGenerator\Processors\Status\MainPage as MainPageProcessor;
+use Symfony\Component\Console\Input\InputOption;
 
 class Status extends Command
 {
@@ -19,6 +21,13 @@ class Status extends Command
     {
         return parent::configure()
             ->setName(CommandName::STATUS())
-            ->setDescription('Updates documentation with the status of translations');
+            ->setDescription('Updates documentation with the status of translations')
+            ->addOption(
+                Option::COLUMNS(),
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'Defines the number of columns generated for the locales table on the general status page',
+                8
+            );
     }
 }

--- a/src/Concerns/Parameters.php
+++ b/src/Concerns/Parameters.php
@@ -48,4 +48,9 @@ trait Parameters
     {
         return $this->parameter(Option::VERSION());
     }
+
+    protected function getColumnsParameter(): int
+    {
+        return $this->parameter(Option::COLUMNS());
+    }
 }

--- a/src/Constants/Option.php
+++ b/src/Constants/Option.php
@@ -5,6 +5,7 @@ namespace LaravelLang\StatusGenerator\Constants;
 use ArchTech\Enums\InvokableCases;
 
 /**
+ * @method static string COLUMNS()
  * @method static string COPY()
  * @method static string DIRECTORY()
  * @method static string FILE()
@@ -19,6 +20,7 @@ enum Option: string
 {
     use InvokableCases;
 
+    case COLUMNS   = 'columns';
     case COPY      = 'copy';
     case DIRECTORY = 'directory';
     case FILE      = 'file';

--- a/src/Processors/Status/MainPage.php
+++ b/src/Processors/Status/MainPage.php
@@ -14,8 +14,6 @@ use LaravelLang\StatusGenerator\Objects\Count as CountDto;
 
 class MainPage extends Base
 {
-    protected int $columns = 5;
-
     protected string $complete_template = '[%s&nbsp;✔](statuses/%s.md)';
 
     protected string $missing_template = '[%s&nbsp;❗](statuses/%s.md)';
@@ -42,7 +40,9 @@ class MainPage extends Base
 
             $content = $this->table;
 
-            $page = Page::make()->stub(Stub::STATUS)->data(compact('content', 'count_all', 'count_diff', 'count_diff_percents'));
+            $page = Page::make()->stub(Stub::STATUS)->data(
+                compact('content', 'count_all', 'count_diff', 'count_diff_percents')
+            );
 
             File::store($this->getTargetStatus(), (string) $page);
         });
@@ -82,7 +82,7 @@ class MainPage extends Base
      */
     protected function rows(): array
     {
-        return array_chunk($this->counter->toArray(), $this->columns);
+        return array_chunk($this->counter->toArray(), $this->getColumnsParameter());
     }
 
     protected function getTargetStatus(): string


### PR DESCRIPTION
By default, on the main page of translation statuses, locales will be placed in 8 columns.

This value can be changed by specifying the `--columns` parameter.

For example:

```bash
vendor/bin/lang status --columns=5
```

Result:

![image](https://github.com/Laravel-Lang/status-generator/assets/10347617/36f86153-2b1f-4a47-a3d9-7c62d430cab7)
